### PR TITLE
Configure link to excalidraw-viewer app

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -13,3 +13,6 @@
 
 /gift https://ed-sa-ma-gift.netlify.app/ 200
 /gift-assets/* https://ed-sa-ma-gift.netlify.app/gift-assets/:splat 200
+
+/diagram https://ed-sa-ma-diagram.netlify.app/ 200
+/diagram-assets/* https://ed-sa-ma-diagram.netlify.app/diagram-assets/:splat 200

--- a/src/content/projects.js
+++ b/src/content/projects.js
@@ -9,11 +9,10 @@ export default [
   },
   {
     title: "Collaboration tool full-stack",
-    link: "https://excalidraw.com/#json=4811329294565376,9VzACSnYk9-NngsEmg2EUQ",
+    link: "/diagram",
     image: "assets/images/Excalidraw_diagram.png",
     description:
       'In this tool the front-end framework was React plus <a href="https://material-ui.com/" target="_blank" rel="noopener noreferer">Material UI</a> as component library and the back end was implemented using <a href="https://cloud.google.com/" target="_blank" rel="noopener noreferer">Google Cloud</a> services like Firebase (Back-end architecture diagram inside).',
-    alt: "excalidraw diagram miniature",
-    openInNewTab: true
+    alt: "excalidraw diagram miniature"
   }
 ];


### PR DESCRIPTION
# Description

List of changes included in this PR:

1. After `excalidraw-viewer` project has been put online [here](https://ed-sa-ma-diagram.netlify.app/), this PR connects the link in portfolio section to that site and makes the link open in the same tab (as it happens with the other sub-project link).
2. Additionally one new re-direct it configured to be able to access the diagram as a route part of the main websile ([ed-sa-ma.com/diagram](https://ed-sa-ma.com/diagram)).